### PR TITLE
Add 2‑page React frontend (port 3000) and FastAPI backend for Crime Action & Model Lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,14 @@ A simple Streamlit app showing an internal tool that lets you manage, and visual
    ```
    $ streamlit run streamlit_app.py
    ```
+
+## Frontend/Backend split dashboard (Milestone 3)
+
+This repository now also contains:
+- `backend/`: FastAPI service for TiDB queries and model-report endpoints.
+- `frontend/`: Vite + React dashboard (runs on port `3000`) with only two pages:
+  1. Crime Action
+  2. Model Lab
+
+See `backend/README.md` and `frontend/README.md` for start commands.
+

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,18 @@
+# Backend API
+
+## Run
+
+```bash
+cd backend
+pip install -r requirements.txt
+uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+```
+
+APIs used by frontend:
+- `/api/crime/current-month-community`
+- `/api/crime/predicted-next-month-risk`
+- `/api/crime/ten-year-trend`
+- `/api/crime/current-month-top10-primary-type`
+- `/api/crime/raw-data`
+- `/api/model/metrics`
+- `/api/model/feature-importance`

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+from fastapi import FastAPI, Query
+from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy import text
+
+from tidb_utils import create_tidb_engine, resolve_chicago_table_name
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+HOLDOUT_PRED_PATH = ROOT_DIR / "experiment/new_cross_validation/reports/holdout_2025_predictions_xgboost.csv"
+METRICS_PATH = ROOT_DIR / "experiment/new_ablation_shap/reports/with_hardship_metrics.csv"
+FEATURE_IMPORTANCE_PATH = ROOT_DIR / "experiment/new_ablation_shap/reports/shap_global_importance.csv"
+
+app = FastAPI(title="Predictive Policing API", version="1.0.0")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+_engine = create_tidb_engine()
+_table = resolve_chicago_table_name(_engine)
+
+
+def _to_records(df: pd.DataFrame) -> list[dict[str, Any]]:
+    clean = df.replace({pd.NA: None})
+    return clean.to_dict(orient="records")
+
+
+@app.get("/api/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/api/crime/current-month-community")
+def current_month_community() -> dict[str, Any]:
+    query = text(
+        f"""
+        WITH latest_month AS (
+          SELECT DATE_FORMAT(MAX(`DATE`), '%Y-%m-01') AS month_start
+          FROM `{_table}`
+          WHERE `DATE` IS NOT NULL
+        )
+        SELECT
+          CAST(`COMMUNITY_AREA` AS UNSIGNED) AS community_area,
+          COUNT(*) AS crime_count,
+          lm.month_start AS month_start
+        FROM `{_table}` t
+        CROSS JOIN latest_month lm
+        WHERE DATE_FORMAT(t.`DATE`, '%Y-%m-01') = lm.month_start
+          AND t.`COMMUNITY_AREA` IS NOT NULL
+          AND t.`COMMUNITY_AREA` REGEXP '^[0-9]+$'
+        GROUP BY CAST(t.`COMMUNITY_AREA` AS UNSIGNED), lm.month_start
+        ORDER BY crime_count DESC
+        """
+    )
+    with _engine.connect() as conn:
+        df = pd.read_sql(query, conn)
+
+    month_start = df["month_start"].iloc[0] if not df.empty else None
+    if not df.empty:
+        df["community_area"] = df["community_area"].astype(int).astype(str)
+
+    return {"month_start": month_start, "data": _to_records(df.drop(columns=["month_start"], errors="ignore"))}
+
+
+@app.get("/api/crime/predicted-next-month-risk")
+def predicted_next_month_risk() -> dict[str, Any]:
+    pred_df = pd.read_csv(HOLDOUT_PRED_PATH)
+    pred_df["target_month"] = pd.to_datetime(pred_df["target_month"], errors="coerce")
+    latest_target = pred_df["target_month"].max()
+
+    latest_df = pred_df[pred_df["target_month"] == latest_target].copy()
+    latest_df = latest_df.sort_values("pred_prob", ascending=False)
+    latest_df["risk_level"] = pd.qcut(
+        latest_df["pred_prob"],
+        q=5,
+        labels=["Very Low", "Low", "Medium", "High", "Very High"],
+        duplicates="drop",
+    )
+    latest_df["community_area"] = latest_df["community_area"].astype(int).astype(str)
+
+    return {
+        "target_month": latest_target.strftime("%Y-%m-01") if pd.notna(latest_target) else None,
+        "data": _to_records(latest_df[["community_area", "pred_prob", "pred_label", "risk_level"]]),
+    }
+
+
+@app.get("/api/crime/ten-year-trend")
+def ten_year_trend() -> dict[str, Any]:
+    query = text(
+        f"""
+        SELECT
+            DATE_FORMAT(`DATE`, '%Y-%m-01') AS month,
+            COUNT(*) AS crime_count
+        FROM `{_table}`
+        WHERE `DATE` IS NOT NULL
+        GROUP BY DATE_FORMAT(`DATE`, '%Y-%m-01')
+        ORDER BY month
+        """
+    )
+    with _engine.connect() as conn:
+        df = pd.read_sql(query, conn)
+    return {"data": _to_records(df)}
+
+
+@app.get("/api/crime/current-month-top10-primary-type")
+def current_month_top10_primary_type() -> dict[str, Any]:
+    query = text(
+        f"""
+        WITH latest_month AS (
+          SELECT DATE_FORMAT(MAX(`DATE`), '%Y-%m-01') AS month_start
+          FROM `{_table}`
+          WHERE `DATE` IS NOT NULL
+        )
+        SELECT
+          COALESCE(NULLIF(TRIM(`PRIMARY_TYPE`), ''), 'UNKNOWN') AS primary_type,
+          COUNT(*) AS crime_count,
+          lm.month_start AS month_start
+        FROM `{_table}` t
+        CROSS JOIN latest_month lm
+        WHERE DATE_FORMAT(t.`DATE`, '%Y-%m-01') = lm.month_start
+        GROUP BY COALESCE(NULLIF(TRIM(`PRIMARY_TYPE`), ''), 'UNKNOWN'), lm.month_start
+        ORDER BY crime_count DESC
+        LIMIT 10
+        """
+    )
+    with _engine.connect() as conn:
+        df = pd.read_sql(query, conn)
+    month_start = df["month_start"].iloc[0] if not df.empty else None
+    return {"month_start": month_start, "data": _to_records(df.drop(columns=["month_start"], errors="ignore"))}
+
+
+@app.get("/api/crime/raw-data")
+def raw_data(limit: int = Query(default=200, ge=1, le=2000)) -> dict[str, Any]:
+    query = text(
+        f"""
+        SELECT
+            `ID` AS id,
+            `DATE` AS date,
+            `PRIMARY_TYPE` AS primary_type,
+            `DESCRIPTION` AS description,
+            `COMMUNITY_AREA` AS community_area,
+            `ARREST` AS arrest,
+            `DOMESTIC` AS domestic
+        FROM `{_table}`
+        ORDER BY `DATE` DESC
+        LIMIT :limit
+        """
+    )
+    with _engine.connect() as conn:
+        df = pd.read_sql(query, conn, params={"limit": limit})
+
+    return {"limit": limit, "data": _to_records(df)}
+
+
+@app.get("/api/model/metrics")
+def model_metrics() -> dict[str, Any]:
+    metrics_df = pd.read_csv(METRICS_PATH)
+    return {"data": _to_records(metrics_df)}
+
+
+@app.get("/api/model/feature-importance")
+def model_feature_importance(top_n: int = Query(default=15, ge=5, le=30)) -> dict[str, Any]:
+    fi_df = pd.read_csv(FEATURE_IMPORTANCE_PATH).sort_values("mean_abs_shap", ascending=False).head(top_n)
+    return {"data": _to_records(fi_df)}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,13 @@
+fastapi==0.121.2
+uvicorn[standard]==0.38.0
+pydantic==2.12.4
+sqlalchemy==2.0.35
+pymysql==1.1.2
+python-dotenv==1.2.1
+pandas==2.2.2
+numpy==1.26.4
+requests==2.32.3
+
+# test/client support used by backend/tests
+httpx==0.28.1
+pytest==8.3.3

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,13 @@
+# Frontend (Port 3000)
+
+## Run
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The app exposes two pages only:
+- `Crime Action`
+- `Model Lab`

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Predictive Policing Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "predictive-policing-frontend",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 0.0.0.0 --port 3000",
+    "build": "vite build",
+    "preview": "vite preview --port 3000"
+  },
+  "dependencies": {
+    "axios": "^1.8.4",
+    "plotly.js-dist-min": "^3.0.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-plotly.js": "^2.6.0",
+    "react-router-dom": "^6.30.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.4",
+    "vite": "^6.2.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,28 @@
+import { NavLink, Route, Routes } from 'react-router-dom'
+import CrimeActionPage from './pages/CrimeActionPage'
+import ModelLabPage from './pages/ModelLabPage'
+
+export default function App() {
+  return (
+    <div className="app-shell">
+      <header className="topbar">
+        <h1>Chicago Predictive Policing Dashboard</h1>
+        <nav>
+          <NavLink to="/" end className={({ isActive }) => (isActive ? 'active' : '')}>
+            Crime Action
+          </NavLink>
+          <NavLink to="/model-lab" className={({ isActive }) => (isActive ? 'active' : '')}>
+            Model Lab
+          </NavLink>
+        </nav>
+      </header>
+
+      <main>
+        <Routes>
+          <Route path="/" element={<CrimeActionPage />} />
+          <Route path="/model-lab" element={<ModelLabPage />} />
+        </Routes>
+      </main>
+    </div>
+  )
+}

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,12 @@
+import axios from 'axios'
+
+const api = axios.create({ baseURL: '/' })
+
+export const fetchCurrentMonthCommunity = async () => (await api.get('/api/crime/current-month-community')).data
+export const fetchPredictedRisk = async () => (await api.get('/api/crime/predicted-next-month-risk')).data
+export const fetchTenYearTrend = async () => (await api.get('/api/crime/ten-year-trend')).data
+export const fetchTop10PrimaryType = async () => (await api.get('/api/crime/current-month-top10-primary-type')).data
+export const fetchRawData = async (limit = 200) => (await api.get(`/api/crime/raw-data?limit=${limit}`)).data
+
+export const fetchModelMetrics = async () => (await api.get('/api/model/metrics')).data
+export const fetchFeatureImportance = async () => (await api.get('/api/model/feature-importance')).data

--- a/frontend/src/components/ChartCard.jsx
+++ b/frontend/src/components/ChartCard.jsx
@@ -1,0 +1,11 @@
+export default function ChartCard({ title, subtitle, children }) {
+  return (
+    <section className="card">
+      <div className="card-header">
+        <h3>{title}</h3>
+        {subtitle ? <p>{subtitle}</p> : null}
+      </div>
+      <div className="card-body">{children}</div>
+    </section>
+  )
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
+import App from './App'
+import './styles.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>,
+)

--- a/frontend/src/pages/CrimeActionPage.jsx
+++ b/frontend/src/pages/CrimeActionPage.jsx
@@ -1,0 +1,156 @@
+import { useEffect, useMemo, useState } from 'react'
+import Plot from 'react-plotly.js'
+import ChartCard from '../components/ChartCard'
+import {
+  fetchCurrentMonthCommunity,
+  fetchPredictedRisk,
+  fetchRawData,
+  fetchTenYearTrend,
+  fetchTop10PrimaryType,
+} from '../api'
+
+export default function CrimeActionPage() {
+  const [communityDist, setCommunityDist] = useState({ month_start: null, data: [] })
+  const [riskDist, setRiskDist] = useState({ target_month: null, data: [] })
+  const [trend, setTrend] = useState({ data: [] })
+  const [topTypes, setTopTypes] = useState({ month_start: null, data: [] })
+  const [rawData, setRawData] = useState({ data: [] })
+
+  useEffect(() => {
+    Promise.all([
+      fetchCurrentMonthCommunity(),
+      fetchPredictedRisk(),
+      fetchTenYearTrend(),
+      fetchTop10PrimaryType(),
+      fetchRawData(200),
+    ]).then(([a, b, c, d, e]) => {
+      setCommunityDist(a)
+      setRiskDist(b)
+      setTrend(c)
+      setTopTypes(d)
+      setRawData(e)
+    })
+  }, [])
+
+  const topCommunity = useMemo(() => communityDist.data.slice(0, 20), [communityDist])
+  const topRisk = useMemo(() => riskDist.data.slice(0, 20), [riskDist])
+
+  return (
+    <div className="page">
+      <h2>Crime Action</h2>
+      <p className="subtitle">Current situation + next-month risk + historical trend + raw TiDB data.</p>
+
+      <div className="chart-grid">
+        <ChartCard
+          title="Current Month Crime Count by Community"
+          subtitle={communityDist.month_start ? `Month: ${communityDist.month_start}` : ''}
+        >
+          <Plot
+            data={[
+              {
+                type: 'bar',
+                x: topCommunity.map((d) => d.community_area),
+                y: topCommunity.map((d) => d.crime_count),
+                marker: { color: '#2563eb' },
+              },
+            ]}
+            layout={{ margin: { l: 40, r: 10, t: 10, b: 40 }, xaxis: { title: 'Community Area' }, yaxis: { title: 'Crime Count' } }}
+            style={{ width: '100%', height: '100%' }}
+            useResizeHandler
+          />
+        </ChartCard>
+
+        <ChartCard
+          title="Predicted High-Risk Distribution (Next Month)"
+          subtitle={riskDist.target_month ? `Target Month: ${riskDist.target_month}` : ''}
+        >
+          <Plot
+            data={[
+              {
+                type: 'bar',
+                x: topRisk.map((d) => d.community_area),
+                y: topRisk.map((d) => d.pred_prob),
+                marker: { color: '#dc2626' },
+              },
+            ]}
+            layout={{ margin: { l: 40, r: 10, t: 10, b: 40 }, xaxis: { title: 'Community Area' }, yaxis: { title: 'Predicted Risk Probability' } }}
+            style={{ width: '100%', height: '100%' }}
+            useResizeHandler
+          />
+        </ChartCard>
+
+        <ChartCard title="10-Year Crime Count Trend (Monthly)">
+          <Plot
+            data={[
+              {
+                type: 'scatter',
+                mode: 'lines',
+                x: trend.data.map((d) => d.month),
+                y: trend.data.map((d) => d.crime_count),
+                line: { color: '#0f766e', width: 2 },
+              },
+            ]}
+            layout={{ margin: { l: 40, r: 10, t: 10, b: 40 }, xaxis: { title: 'Month' }, yaxis: { title: 'Crime Count' } }}
+            style={{ width: '100%', height: '100%' }}
+            useResizeHandler
+          />
+        </ChartCard>
+
+        <ChartCard
+          title="Top 10 Primary Type (Current Month)"
+          subtitle={topTypes.month_start ? `Month: ${topTypes.month_start}` : ''}
+        >
+          <Plot
+            data={[
+              {
+                type: 'bar',
+                orientation: 'h',
+                x: topTypes.data.map((d) => d.crime_count).reverse(),
+                y: topTypes.data.map((d) => d.primary_type).reverse(),
+                marker: { color: '#7c3aed' },
+              },
+            ]}
+            layout={{ margin: { l: 130, r: 10, t: 10, b: 40 }, xaxis: { title: 'Crime Count' }, yaxis: { title: 'Primary Type' } }}
+            style={{ width: '100%', height: '100%' }}
+            useResizeHandler
+          />
+        </ChartCard>
+      </div>
+
+      <section className="card raw-table-card">
+        <div className="card-header">
+          <h3>Raw Data Table (from TiDB)</h3>
+          <p>Latest 200 records</p>
+        </div>
+        <div className="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Date</th>
+                <th>Primary Type</th>
+                <th>Description</th>
+                <th>Community</th>
+                <th>Arrest</th>
+                <th>Domestic</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rawData.data.map((row) => (
+                <tr key={`${row.id}-${row.date}`}>
+                  <td>{row.id}</td>
+                  <td>{row.date}</td>
+                  <td>{row.primary_type}</td>
+                  <td>{row.description}</td>
+                  <td>{row.community_area}</td>
+                  <td>{String(row.arrest)}</td>
+                  <td>{String(row.domestic)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/pages/ModelLabPage.jsx
+++ b/frontend/src/pages/ModelLabPage.jsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react'
+import Plot from 'react-plotly.js'
+import ChartCard from '../components/ChartCard'
+import { fetchFeatureImportance, fetchModelMetrics } from '../api'
+
+export default function ModelLabPage() {
+  const [metrics, setMetrics] = useState({ data: [] })
+  const [importance, setImportance] = useState({ data: [] })
+
+  useEffect(() => {
+    Promise.all([fetchModelMetrics(), fetchFeatureImportance()]).then(([a, b]) => {
+      setMetrics(a)
+      setImportance(b)
+    })
+  }, [])
+
+  return (
+    <div className="page">
+      <h2>Model Lab</h2>
+      <p className="subtitle">Model predictive capability and feature importance.</p>
+
+      <div className="chart-grid single-col">
+        <ChartCard title="Model Predictive Metrics (with hardship features)">
+          <Plot
+            data={[
+              {
+                type: 'bar',
+                x: metrics.data.map((d) => d.model),
+                y: metrics.data.map((d) => d.test_roc_auc),
+                name: 'Test ROC-AUC',
+                marker: { color: '#16a34a' },
+              },
+              {
+                type: 'bar',
+                x: metrics.data.map((d) => d.model),
+                y: metrics.data.map((d) => d.test_pr_auc),
+                name: 'Test PR-AUC',
+                marker: { color: '#0284c7' },
+              },
+              {
+                type: 'bar',
+                x: metrics.data.map((d) => d.model),
+                y: metrics.data.map((d) => d.test_f1),
+                name: 'Test F1',
+                marker: { color: '#f59e0b' },
+              },
+            ]}
+            layout={{ barmode: 'group', margin: { l: 40, r: 10, t: 10, b: 40 }, yaxis: { title: 'Score' } }}
+            style={{ width: '100%', height: '100%' }}
+            useResizeHandler
+          />
+        </ChartCard>
+
+        <ChartCard title="Feature Importance (Global SHAP)">
+          <Plot
+            data={[
+              {
+                type: 'bar',
+                orientation: 'h',
+                x: importance.data.map((d) => d.mean_abs_shap).reverse(),
+                y: importance.data.map((d) => d.feature).reverse(),
+                marker: { color: '#9333ea' },
+              },
+            ]}
+            layout={{ margin: { l: 180, r: 10, t: 10, b: 40 }, xaxis: { title: 'Mean |SHAP|' } }}
+            style={{ width: '100%', height: '100%' }}
+            useResizeHandler
+          />
+        </ChartCard>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,134 @@
+:root {
+  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
+  color: #0f172a;
+  background: #f8fafc;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+.app-shell {
+  min-height: 100vh;
+}
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 28px;
+  background: #0f172a;
+  color: white;
+}
+
+.topbar h1 {
+  margin: 0;
+  font-size: 20px;
+}
+
+.topbar nav {
+  display: flex;
+  gap: 16px;
+}
+
+.topbar a {
+  color: #cbd5e1;
+  text-decoration: none;
+  padding: 8px 10px;
+  border-radius: 8px;
+}
+
+.topbar a.active {
+  color: white;
+  background: #1d4ed8;
+}
+
+main {
+  padding: 20px;
+}
+
+.page h2 {
+  margin: 0 0 8px;
+}
+
+.subtitle {
+  margin: 0 0 20px;
+  color: #475569;
+}
+
+.chart-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.chart-grid.single-col {
+  grid-template-columns: 1fr;
+}
+
+.card {
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 1px 8px rgba(15, 23, 42, 0.08);
+  overflow: hidden;
+}
+
+.card-header {
+  padding: 14px 16px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.card-header h3 {
+  margin: 0;
+  font-size: 16px;
+}
+
+.card-header p {
+  margin: 4px 0 0;
+  color: #64748b;
+  font-size: 13px;
+}
+
+.card-body {
+  padding: 12px;
+  height: 340px;
+}
+
+.raw-table-card {
+  margin-top: 16px;
+}
+
+.table-wrapper {
+  overflow: auto;
+  max-height: 420px;
+}
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 13px;
+}
+
+th,
+td {
+  padding: 8px 10px;
+  border-bottom: 1px solid #e2e8f0;
+  text-align: left;
+  white-space: nowrap;
+}
+
+th {
+  position: sticky;
+  top: 0;
+  background: #f1f5f9;
+}
+
+@media (max-width: 1024px) {
+  .chart-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+      },
+    },
+  },
+})


### PR DESCRIPTION
### Motivation
- Provide a lightweight two‑page web dashboard (separate frontend/backend) that surfaces the four requested Crime Action charts and a Model Lab page while leaving the existing outer Streamlit app unchanged. 
- Reduce the port‑3000 UI to exactly two pages and remove other UI scope by implementing a focused frontend that consumes a small set of backend endpoints. 
- Expose TiDB queries and model reports through a simple API so the frontend can render charts and a raw data table without modifying the Streamlit layer. 

### Description
- Added a new `backend/` FastAPI service (`backend/main.py`) that connects to TiDB (via `tidb_utils`) and exposes endpoints for current‑month community counts, predicted next‑month risk, 10‑year monthly trend, current‑month top‑10 primary types, raw TiDB records, model metrics and feature importance. 
- Added a new `frontend/` Vite + React app (port `3000`) with two pages: `Crime Action` (`frontend/src/pages/CrimeActionPage.jsx`) which renders the four charts and the raw TiDB table, and `Model Lab` (`frontend/src/pages/ModelLabPage.jsx`) which renders model metrics and SHAP feature importance. 
- Implemented shared frontend pieces (`frontend/src/api.js`, `frontend/src/components/ChartCard.jsx`, `frontend/src/App.jsx`, styles and `vite.config.js` with a proxy to `http://localhost:8000`) and wired API calls to backend routes. 
- Updated documentation (`backend/README.md`, `frontend/README.md`, and root `README.md`) with run instructions; the outer Streamlit app files were not modified. 

### Testing
- `python -m py_compile backend/main.py` was run and succeeded. 
- `npm --prefix frontend install` was attempted but failed with a registry `403` in this environment, which is an external registry/permission issue and not a code error. 
- The backend code was exercised locally by static checks (imports/py_compile); frontend package installation could not be completed due to environment restrictions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2149b7fac8326b55ac4a7f74f6130)